### PR TITLE
Split out common types into descriptor and option packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,7 @@ issues:
       test: "CheckServiceHandlerOption"
     - linters:
         - exhaustive
-      path: check/options.go
+      path: option/options.go
       text: "reflect.Pointer|reflect.Ptr"
     - linters:
         - gocritic

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,3 +101,10 @@ issues:
     - linters:
         - varnamelen
       path: internal/pkg/xslices/xslices.go
+    - linters:
+        - revive
+      path: internal/pkg/compare/compare.go
+    - linters:
+        - gosec
+      path: check/checktest/checktest.go
+      text: "G115:"

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ export GOBIN := $(abspath $(BIN))
 COPYRIGHT_YEARS := 2024
 LICENSE_IGNORE := --ignore testdata/
 
-BUF_VERSION := v1.39.0
-GO_MOD_GOTOOLCHAIN := go1.23.0
-GOLANGCI_LINT_VERSION := v1.60.1
+BUF_VERSION := v1.42.0
+GO_MOD_GOTOOLCHAIN := go1.23.1
+GOLANGCI_LINT_VERSION := v1.60.3
 # https://github.com/golangci/golangci-lint/issues/4837
 GOLANGCI_LINT_GOTOOLCHAIN := $(GO_MOD_GOTOOLCHAIN)
 # Remove when we want to upgrade past Go 1.21

--- a/check/annotation.go
+++ b/check/annotation.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 
 	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
+	descriptorv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/descriptor/v1"
 	"buf.build/go/bufplugin/descriptor"
 )
 
@@ -95,19 +96,19 @@ func (a *annotation) toProto() *checkv1.Annotation {
 	if a == nil {
 		return nil
 	}
-	var protoFileLocation *checkv1.Location
+	var protoFileLocation *descriptorv1.FileLocation
 	if a.fileLocation != nil {
 		protoFileLocation = a.fileLocation.ToProto()
 	}
-	var protoAgainstFileLocation *checkv1.Location
+	var protoAgainstFileLocation *descriptorv1.FileLocation
 	if a.againstFileLocation != nil {
 		protoAgainstFileLocation = a.againstFileLocation.ToProto()
 	}
 	return &checkv1.Annotation{
-		RuleId:          a.RuleID(),
-		Message:         a.Message(),
-		Location:        protoFileLocation,
-		AgainstLocation: protoAgainstFileLocation,
+		RuleId:              a.RuleID(),
+		Message:             a.Message(),
+		FileLocation:        protoFileLocation,
+		AgainstFileLocation: protoAgainstFileLocation,
 	}
 }
 

--- a/check/check_service_handler_test.go
+++ b/check/check_service_handler_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
+	descriptorv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/descriptor/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -40,7 +41,7 @@ func TestCheckServiceHandlerUniqueFiles(t *testing.T) {
 	_, err = checkServiceHandler.Check(
 		context.Background(),
 		&checkv1.CheckRequest{
-			Files: []*checkv1.File{
+			FileDescriptors: []*descriptorv1.FileDescriptor{
 				{
 					FileDescriptorProto: &descriptorpb.FileDescriptorProto{
 						Name:           proto.String("foo.proto"),
@@ -48,7 +49,7 @@ func TestCheckServiceHandlerUniqueFiles(t *testing.T) {
 					},
 				},
 			},
-			AgainstFiles: []*checkv1.File{
+			AgainstFileDescriptors: []*descriptorv1.FileDescriptor{
 				{
 					FileDescriptorProto: &descriptorpb.FileDescriptorProto{
 						Name:           proto.String("foo.proto"),
@@ -63,7 +64,7 @@ func TestCheckServiceHandlerUniqueFiles(t *testing.T) {
 	_, err = checkServiceHandler.Check(
 		context.Background(),
 		&checkv1.CheckRequest{
-			Files: []*checkv1.File{
+			FileDescriptors: []*descriptorv1.FileDescriptor{
 				{
 					FileDescriptorProto: &descriptorpb.FileDescriptorProto{
 						Name:           proto.String("foo.proto"),
@@ -86,7 +87,7 @@ func TestCheckServiceHandlerUniqueFiles(t *testing.T) {
 	_, err = checkServiceHandler.Check(
 		context.Background(),
 		&checkv1.CheckRequest{
-			Files: []*checkv1.File{
+			FileDescriptors: []*descriptorv1.FileDescriptor{
 				{
 					FileDescriptorProto: &descriptorpb.FileDescriptorProto{
 						Name:           proto.String("foo.proto"),
@@ -94,7 +95,7 @@ func TestCheckServiceHandlerUniqueFiles(t *testing.T) {
 					},
 				},
 			},
-			AgainstFiles: []*checkv1.File{
+			AgainstFileDescriptors: []*descriptorv1.FileDescriptor{
 				{
 					FileDescriptorProto: &descriptorpb.FileDescriptorProto{
 						Name:           proto.String("bar.proto"),

--- a/check/checktest/checktest.go
+++ b/check/checktest/checktest.go
@@ -29,6 +29,7 @@ import (
 	"buf.build/go/bufplugin/check"
 	"buf.build/go/bufplugin/descriptor"
 	"buf.build/go/bufplugin/internal/pkg/xslices"
+	"buf.build/go/bufplugin/option"
 	"github.com/bufbuild/protocompile"
 	"github.com/bufbuild/protocompile/linker"
 	"github.com/bufbuild/protocompile/parser"
@@ -121,7 +122,7 @@ func (r *RequestSpec) ToRequest(ctx context.Context) (check.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	options, err := check.NewOptions(r.Options)
+	options, err := option.NewOptions(r.Options)
 	if err != nil {
 		return nil, err
 	}

--- a/check/checktest/checktest.go
+++ b/check/checktest/checktest.go
@@ -296,7 +296,7 @@ func expectedAnnotationForAnnotation(annotation check.Annotation) ExpectedAnnota
 	}
 	if fileLocation := annotation.FileLocation(); fileLocation != nil {
 		expectedAnnotation.FileLocation = &ExpectedFileLocation{
-			FileName:    fileLocation.FileDescriptor().Protoreflect().Path(),
+			FileName:    fileLocation.FileDescriptor().ProtoreflectFileDescriptor().Path(),
 			StartLine:   fileLocation.StartLine(),
 			StartColumn: fileLocation.StartColumn(),
 			EndLine:     fileLocation.EndLine(),
@@ -305,7 +305,7 @@ func expectedAnnotationForAnnotation(annotation check.Annotation) ExpectedAnnota
 	}
 	if againstFileLocation := annotation.AgainstFileLocation(); againstFileLocation != nil {
 		expectedAnnotation.AgainstFileLocation = &ExpectedFileLocation{
-			FileName:    againstFileLocation.FileDescriptor().Protoreflect().Path(),
+			FileName:    againstFileLocation.FileDescriptor().ProtoreflectFileDescriptor().Path(),
 			StartLine:   againstFileLocation.StartLine(),
 			StartColumn: againstFileLocation.StartColumn(),
 			EndLine:     againstFileLocation.EndLine(),

--- a/check/checktest/checktest.go
+++ b/check/checktest/checktest.go
@@ -27,6 +27,7 @@ import (
 
 	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
 	"buf.build/go/bufplugin/check"
+	"buf.build/go/bufplugin/descriptor"
 	"buf.build/go/bufplugin/internal/pkg/xslices"
 	"github.com/bufbuild/protocompile"
 	"github.com/bufbuild/protocompile/linker"
@@ -116,7 +117,7 @@ func (r *RequestSpec) ToRequest(ctx context.Context) (check.Request, error) {
 		return nil, errors.New("RequestSpec.Files not set")
 	}
 
-	againstFiles, err := r.AgainstFiles.ToFiles(ctx)
+	againstFileDescriptors, err := r.AgainstFiles.ToFileDescriptors(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -125,16 +126,16 @@ func (r *RequestSpec) ToRequest(ctx context.Context) (check.Request, error) {
 		return nil, err
 	}
 	requestOptions := []check.RequestOption{
-		check.WithAgainstFiles(againstFiles),
+		check.WithAgainstFileDescriptors(againstFileDescriptors),
 		check.WithOptions(options),
 		check.WithRuleIDs(r.RuleIDs...),
 	}
 
-	files, err := r.Files.ToFiles(ctx)
+	fileDescriptors, err := r.Files.ToFileDescriptors(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return check.NewRequest(files, requestOptions...)
+	return check.NewRequest(fileDescriptors, requestOptions...)
 }
 
 // ProtoFileSpec specifies files to be compiled for testing.
@@ -160,10 +161,10 @@ type ProtoFileSpec struct {
 	FilePaths []string
 }
 
-// ToFiles compiles the files into check.Files.
+// ToFileDescriptors compiles the files into descriptor.FileDescriptors.
 //
 // If p is nil, this returns an empty slice.
-func (p *ProtoFileSpec) ToFiles(ctx context.Context) ([]check.File, error) {
+func (p *ProtoFileSpec) ToFileDescriptors(ctx context.Context) ([]descriptor.FileDescriptor, error) {
 	if p == nil {
 		return nil, nil
 	}
@@ -185,22 +186,22 @@ type ExpectedAnnotation struct {
 	// against the value in Annotation. That is, it is valid to have an Annotation return
 	// a message but to not set it on ExpectedAnnotation.
 	Message string
-	// Location is the location of the failure.
-	Location *ExpectedLocation
-	// AgainstLocation is the against location of the failure.
-	AgainstLocation *ExpectedLocation
+	// FileLocation is the location of the failure.
+	FileLocation *ExpectedFileLocation
+	// AgainstFileLocation is the against location of the failure.
+	AgainstFileLocation *ExpectedFileLocation
 }
 
 // String implements fmt.Stringer.
 func (ea ExpectedAnnotation) String() string {
 	return "ruleID=\"" + ea.RuleID + "\"" +
 		" message=\"" + ea.Message + "\"" +
-		" location=\"" + ea.Location.String() + "\"" +
-		" againstLocation=\"" + ea.AgainstLocation.String() + "\""
+		" location=\"" + ea.FileLocation.String() + "\"" +
+		" againstLocation=\"" + ea.AgainstFileLocation.String() + "\""
 }
 
-// ExpectedLocation contains the values expected from a Location.
-type ExpectedLocation struct {
+// ExpectedFileLocation contains the values expected from a Location.
+type ExpectedFileLocation struct {
 	// FileName is the name of the file.
 	FileName string
 	// StartLine is the zero-indexed start line.
@@ -214,7 +215,7 @@ type ExpectedLocation struct {
 }
 
 // String implements fmt.Stringer.
-func (el *ExpectedLocation) String() string {
+func (el *ExpectedFileLocation) String() string {
 	if el == nil {
 		return "nil"
 	}
@@ -292,28 +293,28 @@ func expectedAnnotationForAnnotation(annotation check.Annotation) ExpectedAnnota
 		RuleID:  annotation.RuleID(),
 		Message: annotation.Message(),
 	}
-	if location := annotation.Location(); location != nil {
-		expectedAnnotation.Location = &ExpectedLocation{
-			FileName:    location.File().FileDescriptor().Path(),
-			StartLine:   location.StartLine(),
-			StartColumn: location.StartColumn(),
-			EndLine:     location.EndLine(),
-			EndColumn:   location.EndColumn(),
+	if fileLocation := annotation.FileLocation(); fileLocation != nil {
+		expectedAnnotation.FileLocation = &ExpectedFileLocation{
+			FileName:    fileLocation.FileDescriptor().Protoreflect().Path(),
+			StartLine:   fileLocation.StartLine(),
+			StartColumn: fileLocation.StartColumn(),
+			EndLine:     fileLocation.EndLine(),
+			EndColumn:   fileLocation.EndColumn(),
 		}
 	}
-	if againstLocation := annotation.AgainstLocation(); againstLocation != nil {
-		expectedAnnotation.AgainstLocation = &ExpectedLocation{
-			FileName:    againstLocation.File().FileDescriptor().Path(),
-			StartLine:   againstLocation.StartLine(),
-			StartColumn: againstLocation.StartColumn(),
-			EndLine:     againstLocation.EndLine(),
-			EndColumn:   againstLocation.EndColumn(),
+	if againstFileLocation := annotation.AgainstFileLocation(); againstFileLocation != nil {
+		expectedAnnotation.AgainstFileLocation = &ExpectedFileLocation{
+			FileName:    againstFileLocation.FileDescriptor().Protoreflect().Path(),
+			StartLine:   againstFileLocation.StartLine(),
+			StartColumn: againstFileLocation.StartColumn(),
+			EndLine:     againstFileLocation.EndLine(),
+			EndColumn:   againstFileLocation.EndColumn(),
 		}
 	}
 	return expectedAnnotation
 }
 
-func compile(ctx context.Context, dirPaths []string, filePaths []string) ([]check.File, error) {
+func compile(ctx context.Context, dirPaths []string, filePaths []string) ([]descriptor.FileDescriptor, error) {
 	dirPaths = fromSlashPaths(dirPaths)
 	filePaths = fromSlashPaths(filePaths)
 	toSlashFilePathMap := make(map[string]struct{}, len(filePaths))
@@ -351,7 +352,7 @@ func compile(ctx context.Context, dirPaths []string, filePaths []string) ([]chec
 	}
 	fileDescriptorSet := fileDescriptorSetForFileDescriptors(files)
 
-	protoFiles := make([]*checkv1.File, len(fileDescriptorSet.GetFile()))
+	protoFileDescriptors := make([]*checkv1.File, len(fileDescriptorSet.GetFile()))
 	for i, fileDescriptorProto := range fileDescriptorSet.GetFile() {
 		_, isNotImport := toSlashFilePathMap[fileDescriptorProto.GetName()]
 		_, isSyntaxUnspecified := syntaxUnspecifiedFilePaths[fileDescriptorProto.GetName()]
@@ -359,14 +360,14 @@ func compile(ctx context.Context, dirPaths []string, filePaths []string) ([]chec
 			fileDescriptorProto,
 			filePathToUnusedDependencyFilePaths[fileDescriptorProto.GetName()],
 		)
-		protoFiles[i] = &checkv1.File{
+		protoFileDescriptors[i] = &checkv1.File{
 			FileDescriptorProto: fileDescriptorProto,
 			IsImport:            !isNotImport,
 			IsSyntaxUnspecified: isSyntaxUnspecified,
 			UnusedDependency:    unusedDependencyIndexes,
 		}
 	}
-	return check.FilesForProtoFiles(protoFiles)
+	return descriptor.FileDescriptorsForProtoFileDescriptors(protoFileDescriptors)
 }
 
 func unusedDependencyIndexesForFilePathToUnusedDependencyFilePaths(

--- a/check/checktest/checktest.go
+++ b/check/checktest/checktest.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"testing"
 
-	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
+	descriptorv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/descriptor/v1"
 	"buf.build/go/bufplugin/check"
 	"buf.build/go/bufplugin/descriptor"
 	"buf.build/go/bufplugin/internal/pkg/xslices"
@@ -353,7 +353,7 @@ func compile(ctx context.Context, dirPaths []string, filePaths []string) ([]desc
 	}
 	fileDescriptorSet := fileDescriptorSetForFileDescriptors(files)
 
-	protoFileDescriptors := make([]*checkv1.File, len(fileDescriptorSet.GetFile()))
+	protoFileDescriptors := make([]*descriptorv1.FileDescriptor, len(fileDescriptorSet.GetFile()))
 	for i, fileDescriptorProto := range fileDescriptorSet.GetFile() {
 		_, isNotImport := toSlashFilePathMap[fileDescriptorProto.GetName()]
 		_, isSyntaxUnspecified := syntaxUnspecifiedFilePaths[fileDescriptorProto.GetName()]
@@ -361,7 +361,7 @@ func compile(ctx context.Context, dirPaths []string, filePaths []string) ([]desc
 			fileDescriptorProto,
 			filePathToUnusedDependencyFilePaths[fileDescriptorProto.GetName()],
 		)
-		protoFileDescriptors[i] = &checkv1.File{
+		protoFileDescriptors[i] = &descriptorv1.FileDescriptor{
 			FileDescriptorProto: fileDescriptorProto,
 			IsImport:            !isNotImport,
 			IsSyntaxUnspecified: isSyntaxUnspecified,

--- a/check/checkutil/lint.go
+++ b/check/checkutil/lint.go
@@ -74,7 +74,7 @@ func NewFileImportRuleHandler(
 			fileDescriptor descriptor.FileDescriptor,
 		) error {
 			return forEachFileImport(
-				fileDescriptor.Protoreflect(),
+				fileDescriptor.ProtoreflectFileDescriptor(),
 				func(fileImport protoreflect.FileImport) error {
 					return f(ctx, responseWriter, request, fileImport)
 				},
@@ -100,7 +100,7 @@ func NewEnumRuleHandler(
 			fileDescriptor descriptor.FileDescriptor,
 		) error {
 			return forEachEnum(
-				fileDescriptor.Protoreflect(),
+				fileDescriptor.ProtoreflectFileDescriptor(),
 				func(enumDescriptor protoreflect.EnumDescriptor) error {
 					return f(ctx, responseWriter, request, enumDescriptor)
 				},
@@ -152,7 +152,7 @@ func NewMessageRuleHandler(
 			fileDescriptor descriptor.FileDescriptor,
 		) error {
 			return forEachMessage(
-				fileDescriptor.Protoreflect(),
+				fileDescriptor.ProtoreflectFileDescriptor(),
 				func(messageDescriptor protoreflect.MessageDescriptor) error {
 					return f(ctx, responseWriter, request, messageDescriptor)
 				},
@@ -180,7 +180,7 @@ func NewFieldRuleHandler(
 			fileDescriptor descriptor.FileDescriptor,
 		) error {
 			return forEachField(
-				fileDescriptor.Protoreflect(),
+				fileDescriptor.ProtoreflectFileDescriptor(),
 				func(fieldDescriptor protoreflect.FieldDescriptor) error {
 					return f(ctx, responseWriter, request, fieldDescriptor)
 				},
@@ -232,7 +232,7 @@ func NewServiceRuleHandler(
 			fileDescriptor descriptor.FileDescriptor,
 		) error {
 			return forEachService(
-				fileDescriptor.Protoreflect(),
+				fileDescriptor.ProtoreflectFileDescriptor(),
 				func(serviceDescriptor protoreflect.ServiceDescriptor) error {
 					return f(ctx, responseWriter, request, serviceDescriptor)
 				},

--- a/check/checkutil/util.go
+++ b/check/checkutil/util.go
@@ -32,7 +32,7 @@ type container interface {
 func getPathToFileDescriptor(fileDescriptors []descriptor.FileDescriptor) (map[string]descriptor.FileDescriptor, error) {
 	pathToFileDescriptorMap := make(map[string]descriptor.FileDescriptor, len(fileDescriptors))
 	for _, fileDescriptor := range fileDescriptors {
-		path := fileDescriptor.Protoreflect().Path()
+		path := fileDescriptor.ProtoreflectFileDescriptor().Path()
 		if _, ok := pathToFileDescriptorMap[path]; ok {
 			return nil, fmt.Errorf("duplicate file: %q", path)
 		}
@@ -45,7 +45,7 @@ func getFullNameToEnumDescriptor(fileDescriptors []descriptor.FileDescriptor) (m
 	fullNameToEnumDescriptorMap := make(map[protoreflect.FullName]protoreflect.EnumDescriptor)
 	for _, fileDescriptor := range fileDescriptors {
 		if err := forEachEnum(
-			fileDescriptor.Protoreflect(),
+			fileDescriptor.ProtoreflectFileDescriptor(),
 			func(enumDescriptor protoreflect.EnumDescriptor) error {
 				fullName := enumDescriptor.FullName()
 				if _, ok := fullNameToEnumDescriptorMap[fullName]; ok {
@@ -93,7 +93,7 @@ func getFullNameToMessageDescriptor(fileDescriptors []descriptor.FileDescriptor)
 	fullNameToMessageDescriptorMap := make(map[protoreflect.FullName]protoreflect.MessageDescriptor)
 	for _, fileDescriptor := range fileDescriptors {
 		if err := forEachMessage(
-			fileDescriptor.Protoreflect(),
+			fileDescriptor.ProtoreflectFileDescriptor(),
 			func(messageDescriptor protoreflect.MessageDescriptor) error {
 				fullName := messageDescriptor.FullName()
 				if _, ok := fullNameToMessageDescriptorMap[fullName]; ok {
@@ -117,7 +117,7 @@ func getContainingMessageFullNameToNumberToFieldDescriptor(
 	)
 	for _, fileDescriptor := range fileDescriptors {
 		if err := forEachField(
-			fileDescriptor.Protoreflect(),
+			fileDescriptor.ProtoreflectFileDescriptor(),
 			func(fieldDescriptor protoreflect.FieldDescriptor) error {
 				number := fieldDescriptor.Number()
 				containingMessage := fieldDescriptor.ContainingMessage()
@@ -147,7 +147,7 @@ func getFullNameToServiceDescriptor(fileDescriptors []descriptor.FileDescriptor)
 	fullNameToServiceDescriptorMap := make(map[protoreflect.FullName]protoreflect.ServiceDescriptor)
 	for _, fileDescriptor := range fileDescriptors {
 		if err := forEachService(
-			fileDescriptor.Protoreflect(),
+			fileDescriptor.ProtoreflectFileDescriptor(),
 			func(serviceDescriptor protoreflect.ServiceDescriptor) error {
 				fullName := serviceDescriptor.FullName()
 				if _, ok := fullNameToServiceDescriptorMap[fullName]; ok {

--- a/check/client.go
+++ b/check/client.go
@@ -160,12 +160,12 @@ func (c *client) Check(ctx context.Context, request Request, _ ...CheckCallOptio
 				protoAnnotation.GetRuleId(),
 				WithMessage(protoAnnotation.GetMessage()),
 				WithFileNameAndSourcePath(
-					protoAnnotation.GetLocation().GetFileName(),
-					protoAnnotation.GetLocation().GetSourcePath(),
+					protoAnnotation.GetFileLocation().GetFileName(),
+					protoAnnotation.GetFileLocation().GetSourcePath(),
 				),
 				WithAgainstFileNameAndSourcePath(
-					protoAnnotation.GetAgainstLocation().GetFileName(),
-					protoAnnotation.GetAgainstLocation().GetSourcePath(),
+					protoAnnotation.GetAgainstFileLocation().GetFileName(),
+					protoAnnotation.GetAgainstFileLocation().GetSourcePath(),
 				),
 			)
 		}

--- a/check/compare.go
+++ b/check/compare.go
@@ -15,8 +15,9 @@
 package check
 
 import (
-	"slices"
 	"strings"
+
+	"buf.build/go/bufplugin/descriptor"
 )
 
 // CompareAnnotations returns -1 if one < two, 1 if one > two, 0 otherwise.
@@ -34,59 +35,14 @@ func CompareAnnotations(one Annotation, two Annotation) int {
 		return compare
 	}
 
-	if compare := CompareLocations(one.Location(), two.Location()); compare != 0 {
+	if compare := descriptor.CompareFileLocations(one.FileLocation(), two.FileLocation()); compare != 0 {
 		return compare
 	}
 
-	if compare := CompareLocations(one.AgainstLocation(), two.AgainstLocation()); compare != 0 {
+	if compare := descriptor.CompareFileLocations(one.AgainstFileLocation(), two.AgainstFileLocation()); compare != 0 {
 		return compare
 	}
 	return strings.Compare(one.Message(), two.Message())
-}
-
-// CompareLocations returns -1 if one < two, 1 if one > two, 0 otherwise.
-func CompareLocations(one Location, two Location) int {
-	if one == nil && two == nil {
-		return 0
-	}
-	if one == nil && two != nil {
-		return -1
-	}
-	if one != nil && two == nil {
-		return 1
-	}
-	if compare := strings.Compare(one.File().FileDescriptor().Path(), two.File().FileDescriptor().Path()); compare != 0 {
-		return compare
-	}
-
-	if compare := intCompare(one.StartLine(), two.StartLine()); compare != 0 {
-		return compare
-	}
-
-	if compare := intCompare(one.StartColumn(), two.StartColumn()); compare != 0 {
-		return compare
-	}
-
-	if compare := intCompare(one.EndLine(), two.EndLine()); compare != 0 {
-		return compare
-	}
-
-	if compare := intCompare(one.EndColumn(), two.EndColumn()); compare != 0 {
-		return compare
-	}
-
-	if compare := slices.Compare(one.unclonedSourcePath(), two.unclonedSourcePath()); compare != 0 {
-		return compare
-	}
-
-	if compare := strings.Compare(one.LeadingComments(), two.LeadingComments()); compare != 0 {
-		return compare
-	}
-
-	if compare := strings.Compare(one.TrailingComments(), two.TrailingComments()); compare != 0 {
-		return compare
-	}
-	return slices.Compare(one.unclonedLeadingDetachedComments(), two.unclonedLeadingDetachedComments())
 }
 
 // CompareRules returns -1 if one < two, 1 if one > two, 0 otherwise.
@@ -145,14 +101,4 @@ func compareCategorySpecs(one *CategorySpec, two *CategorySpec) int {
 		return 1
 	}
 	return strings.Compare(one.ID, two.ID)
-}
-
-func intCompare(one int, two int) int {
-	if one < two {
-		return -1
-	}
-	if one > two {
-		return 1
-	}
-	return 0
 }

--- a/check/errors.go
+++ b/check/errors.go
@@ -89,31 +89,6 @@ func (o *duplicateRuleOrCategoryIDError) Error() string {
 	return sb.String()
 }
 
-type unexpectedOptionValueTypeError struct {
-	key      string
-	expected any
-	actual   any
-}
-
-func newUnexpectedOptionValueTypeError(key string, expected any, actual any) *unexpectedOptionValueTypeError {
-	return &unexpectedOptionValueTypeError{
-		key:      key,
-		expected: expected,
-		actual:   actual,
-	}
-}
-
-func (u *unexpectedOptionValueTypeError) Error() string {
-	if u == nil {
-		return ""
-	}
-	var sb strings.Builder
-	_, _ = sb.WriteString(`unexpected type for option value "`)
-	_, _ = sb.WriteString(u.key)
-	_, _ = sb.WriteString(fmt.Sprintf(`": expected %T, got %T`, u.expected, u.actual))
-	return sb.String()
-}
-
 type validateRuleSpecError struct {
 	delegate error
 }

--- a/check/internal/example/cmd/buf-plugin-field-lower-snake-case/main_test.go
+++ b/check/internal/example/cmd/buf-plugin-field-lower-snake-case/main_test.go
@@ -39,7 +39,7 @@ func TestSimple(t *testing.T) {
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
 			{
 				RuleID: fieldLowerSnakeCaseRuleID,
-				Location: &checktest.ExpectedLocation{
+				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   6,
 					StartColumn: 2,

--- a/check/internal/example/cmd/buf-plugin-field-option-safe-for-ml/main_test.go
+++ b/check/internal/example/cmd/buf-plugin-field-option-safe-for-ml/main_test.go
@@ -65,7 +65,7 @@ func TestSimpleFailure(t *testing.T) {
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
 			{
 				RuleID: fieldOptionSafeForMLSetRuleID,
-				Location: &checktest.ExpectedLocation{
+				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   8,
 					StartColumn: 2,
@@ -137,14 +137,14 @@ func TestChangeFailure(t *testing.T) {
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
 			{
 				RuleID: fieldOptionSafeForMLStaysTrueRuleID,
-				Location: &checktest.ExpectedLocation{
+				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   8,
 					StartColumn: 2,
 					EndLine:     8,
 					EndColumn:   56,
 				},
-				AgainstLocation: &checktest.ExpectedLocation{
+				AgainstFileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   8,
 					StartColumn: 2,

--- a/check/internal/example/cmd/buf-plugin-syntax-specified/main.go
+++ b/check/internal/example/cmd/buf-plugin-syntax-specified/main.go
@@ -77,7 +77,7 @@ func checkSyntaxSpecified(
 		syntax := fileDescriptor.FileDescriptorProto().GetSyntax()
 		responseWriter.AddAnnotation(
 			check.WithMessagef("Syntax should be specified but was %q.", syntax),
-			check.WithDescriptor(fileDescriptor.Protoreflect()),
+			check.WithDescriptor(fileDescriptor.ProtoreflectFileDescriptor()),
 		)
 	}
 	return nil

--- a/check/internal/example/cmd/buf-plugin-syntax-specified/main.go
+++ b/check/internal/example/cmd/buf-plugin-syntax-specified/main.go
@@ -36,6 +36,7 @@ import (
 
 	"buf.build/go/bufplugin/check"
 	"buf.build/go/bufplugin/check/checkutil"
+	"buf.build/go/bufplugin/descriptor"
 )
 
 // syntaxSpecifiedRuleID is the Rule ID of the syntax specified Rule.
@@ -70,13 +71,13 @@ func checkSyntaxSpecified(
 	_ context.Context,
 	responseWriter check.ResponseWriter,
 	_ check.Request,
-	file check.File,
+	fileDescriptor descriptor.FileDescriptor,
 ) error {
-	if file.IsSyntaxUnspecified() {
-		syntax := file.FileDescriptorProto().GetSyntax()
+	if fileDescriptor.IsSyntaxUnspecified() {
+		syntax := fileDescriptor.FileDescriptorProto().GetSyntax()
 		responseWriter.AddAnnotation(
 			check.WithMessagef("Syntax should be specified but was %q.", syntax),
-			check.WithDescriptor(file.FileDescriptor()),
+			check.WithDescriptor(fileDescriptor.Protoreflect()),
 		)
 	}
 	return nil

--- a/check/internal/example/cmd/buf-plugin-syntax-specified/main_test.go
+++ b/check/internal/example/cmd/buf-plugin-syntax-specified/main_test.go
@@ -53,7 +53,7 @@ func TestSimpleFailure(t *testing.T) {
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
 			{
 				RuleID: syntaxSpecifiedRuleID,
-				Location: &checktest.ExpectedLocation{
+				FileLocation: &checktest.ExpectedFileLocation{
 					FileName: "simple.proto",
 				},
 			},

--- a/check/internal/example/cmd/buf-plugin-timestamp-suffix/main.go
+++ b/check/internal/example/cmd/buf-plugin-timestamp-suffix/main.go
@@ -47,6 +47,7 @@ import (
 
 	"buf.build/go/bufplugin/check"
 	"buf.build/go/bufplugin/check/checkutil"
+	"buf.build/go/bufplugin/option"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -89,7 +90,7 @@ func checkTimestampSuffix(
 	fieldDescriptor protoreflect.FieldDescriptor,
 ) error {
 	timestampSuffix := defaultTimestampSuffix
-	timestampSuffixOptionValue, err := check.GetStringValue(request.Options(), timestampSuffixOptionKey)
+	timestampSuffixOptionValue, err := option.GetStringValue(request.Options(), timestampSuffixOptionKey)
 	if err != nil {
 		return err
 	}

--- a/check/internal/example/cmd/buf-plugin-timestamp-suffix/main_test.go
+++ b/check/internal/example/cmd/buf-plugin-timestamp-suffix/main_test.go
@@ -42,7 +42,7 @@ func TestSimple(t *testing.T) {
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
 			{
 				RuleID: timestampSuffixRuleID,
-				Location: &checktest.ExpectedLocation{
+				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "simple.proto",
 					StartLine:   8,
 					StartColumn: 2,
@@ -71,7 +71,7 @@ func TestOption(t *testing.T) {
 		ExpectedAnnotations: []checktest.ExpectedAnnotation{
 			{
 				RuleID: timestampSuffixRuleID,
-				Location: &checktest.ExpectedLocation{
+				FileLocation: &checktest.ExpectedFileLocation{
 					FileName:    "option.proto",
 					StartLine:   8,
 					StartColumn: 2,

--- a/check/request.go
+++ b/check/request.go
@@ -108,11 +108,11 @@ func WithRuleIDs(ruleIDs ...string) RequestOption {
 
 // RequestForProtoRequest returns a new Request for the given checkv1.Request.
 func RequestForProtoRequest(protoRequest *checkv1.CheckRequest) (Request, error) {
-	fileDescriptors, err := descriptor.FileDescriptorsForProtoFileDescriptors(protoRequest.GetFiles())
+	fileDescriptors, err := descriptor.FileDescriptorsForProtoFileDescriptors(protoRequest.GetFileDescriptors())
 	if err != nil {
 		return nil, err
 	}
-	againstFileDescriptors, err := descriptor.FileDescriptorsForProtoFileDescriptors(protoRequest.GetAgainstFiles())
+	againstFileDescriptors, err := descriptor.FileDescriptorsForProtoFileDescriptors(protoRequest.GetAgainstFileDescriptors())
 	if err != nil {
 		return nil, err
 	}
@@ -195,9 +195,9 @@ func (r *request) toProtos() ([]*checkv1.CheckRequest, error) {
 	if len(r.ruleIDs) == 0 {
 		return []*checkv1.CheckRequest{
 			{
-				Files:        protoFileDescriptors,
-				AgainstFiles: protoAgainstFileDescriptors,
-				Options:      protoOptions,
+				FileDescriptors:        protoFileDescriptors,
+				AgainstFileDescriptors: protoAgainstFileDescriptors,
+				Options:                protoOptions,
 			},
 		}, nil
 	}
@@ -211,10 +211,10 @@ func (r *request) toProtos() ([]*checkv1.CheckRequest, error) {
 		checkRequests = append(
 			checkRequests,
 			&checkv1.CheckRequest{
-				Files:        protoFileDescriptors,
-				AgainstFiles: protoAgainstFileDescriptors,
-				Options:      protoOptions,
-				RuleIds:      r.ruleIDs[start:end],
+				FileDescriptors:        protoFileDescriptors,
+				AgainstFileDescriptors: protoAgainstFileDescriptors,
+				Options:                protoOptions,
+				RuleIds:                r.ruleIDs[start:end],
 			},
 		)
 	}

--- a/check/request.go
+++ b/check/request.go
@@ -15,10 +15,12 @@
 package check
 
 import (
+	"fmt"
 	"slices"
 	"sort"
 
 	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
+	"buf.build/go/bufplugin/descriptor"
 	"buf.build/go/bufplugin/internal/pkg/xslices"
 )
 
@@ -26,18 +28,20 @@ const checkRuleIDPageSize = 250
 
 // Request is a request to a plugin to run checks.
 type Request interface {
-	// Files contains the files to check.
+	// FileDescriptors contains the FileDescriptors to check.
 	//
 	// Will never be nil or empty.
 	//
-	// Files are guaranteed to be unique with respect to their file name
-	Files() []File
-	// AgainstFiles contains the files to check against, in the case of breaking change plugins.
+	// FileDescriptors are guaranteed to be unique with respect to their name.
+	FileDescriptors() []descriptor.FileDescriptor
+	// AgainstFileDescriptors contains the FileDescriptors to check against, in the
+	// case of breaking change plugins.
 	//
-	// May be empty, including in the case where we did actually specify against files.
+	// May be empty, including in the case where we did actually specify against
+	// FileDescriptors.
 	//
-	// Files are guaranteed to be unique with respect to their file name
-	AgainstFiles() []File
+	// FileDescriptors are guaranteed to be unique with respect to their name.
+	AgainstFileDescriptors() []descriptor.FileDescriptor
 	// Options contains any options passed to the plugin.
 	//
 	// Will never be nil, but may have no values.
@@ -63,24 +67,24 @@ type Request interface {
 	isRequest()
 }
 
-// NewRequest returns a new Request for the given Files.
+// NewRequest returns a new Request for the given FileDescriptors.
 //
-// Files are always required. To set against Files or options, use
-// WithAgainstFiles and WithOption.
+// FileDescriptors are always required. To set against FileDescriptors or options, use
+// WithAgainstFileDescriptors and WithOption.
 func NewRequest(
-	files []File,
+	fileDescriptors []descriptor.FileDescriptor,
 	options ...RequestOption,
 ) (Request, error) {
-	return newRequest(files, options...)
+	return newRequest(fileDescriptors, options...)
 }
 
 // RequestOption is an option for a new Request.
 type RequestOption func(*requestOptions)
 
-// WithAgainstFiles adds the given against Files to the Request.
-func WithAgainstFiles(againstFiles []File) RequestOption {
+// WithAgainstFileDescriptors adds the given against FileDescriptors to the Request.
+func WithAgainstFileDescriptors(againstFileDescriptors []descriptor.FileDescriptor) RequestOption {
 	return func(requestOptions *requestOptions) {
-		requestOptions.againstFiles = againstFiles
+		requestOptions.againstFileDescriptors = againstFileDescriptors
 	}
 }
 
@@ -103,11 +107,11 @@ func WithRuleIDs(ruleIDs ...string) RequestOption {
 
 // RequestForProtoRequest returns a new Request for the given checkv1.Request.
 func RequestForProtoRequest(protoRequest *checkv1.CheckRequest) (Request, error) {
-	files, err := FilesForProtoFiles(protoRequest.GetFiles())
+	fileDescriptors, err := descriptor.FileDescriptorsForProtoFileDescriptors(protoRequest.GetFiles())
 	if err != nil {
 		return nil, err
 	}
-	againstFiles, err := FilesForProtoFiles(protoRequest.GetAgainstFiles())
+	againstFileDescriptors, err := descriptor.FileDescriptorsForProtoFileDescriptors(protoRequest.GetAgainstFiles())
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +120,8 @@ func RequestForProtoRequest(protoRequest *checkv1.CheckRequest) (Request, error)
 		return nil, err
 	}
 	return NewRequest(
-		files,
-		WithAgainstFiles(againstFiles),
+		fileDescriptors,
+		WithAgainstFileDescriptors(againstFileDescriptors),
 		WithOptions(options),
 		WithRuleIDs(protoRequest.GetRuleIds()...),
 	)
@@ -126,14 +130,14 @@ func RequestForProtoRequest(protoRequest *checkv1.CheckRequest) (Request, error)
 // *** PRIVATE ***
 
 type request struct {
-	files        []File
-	againstFiles []File
-	options      Options
-	ruleIDs      []string
+	fileDescriptors        []descriptor.FileDescriptor
+	againstFileDescriptors []descriptor.FileDescriptor
+	options                Options
+	ruleIDs                []string
 }
 
 func newRequest(
-	files []File,
+	fileDescriptors []descriptor.FileDescriptor,
 	options ...RequestOption,
 ) (*request, error) {
 	requestOptions := newRequestOptions()
@@ -147,26 +151,26 @@ func newRequest(
 		return nil, err
 	}
 	sort.Strings(requestOptions.ruleIDs)
-	if err := validateFiles(files); err != nil {
+	if err := validateFileDescriptors(fileDescriptors); err != nil {
 		return nil, err
 	}
-	if err := validateFiles(requestOptions.againstFiles); err != nil {
+	if err := validateFileDescriptors(requestOptions.againstFileDescriptors); err != nil {
 		return nil, err
 	}
 	return &request{
-		files:        files,
-		againstFiles: requestOptions.againstFiles,
-		options:      requestOptions.options,
-		ruleIDs:      requestOptions.ruleIDs,
+		fileDescriptors:        fileDescriptors,
+		againstFileDescriptors: requestOptions.againstFileDescriptors,
+		options:                requestOptions.options,
+		ruleIDs:                requestOptions.ruleIDs,
 	}, nil
 }
 
-func (r *request) Files() []File {
-	return slices.Clone(r.files)
+func (r *request) FileDescriptors() []descriptor.FileDescriptor {
+	return slices.Clone(r.fileDescriptors)
 }
 
-func (r *request) AgainstFiles() []File {
-	return slices.Clone(r.againstFiles)
+func (r *request) AgainstFileDescriptors() []descriptor.FileDescriptor {
+	return slices.Clone(r.againstFileDescriptors)
 }
 
 func (r *request) Options() Options {
@@ -181,8 +185,8 @@ func (r *request) toProtos() ([]*checkv1.CheckRequest, error) {
 	if r == nil {
 		return nil, nil
 	}
-	protoFiles := xslices.Map(r.files, File.toProto)
-	protoAgainstFiles := xslices.Map(r.againstFiles, File.toProto)
+	protoFileDescriptors := xslices.Map(r.fileDescriptors, descriptor.FileDescriptor.ToProto)
+	protoAgainstFileDescriptors := xslices.Map(r.againstFileDescriptors, descriptor.FileDescriptor.ToProto)
 	protoOptions, err := r.options.toProto()
 	if err != nil {
 		return nil, err
@@ -190,8 +194,8 @@ func (r *request) toProtos() ([]*checkv1.CheckRequest, error) {
 	if len(r.ruleIDs) == 0 {
 		return []*checkv1.CheckRequest{
 			{
-				Files:        protoFiles,
-				AgainstFiles: protoAgainstFiles,
+				Files:        protoFileDescriptors,
+				AgainstFiles: protoAgainstFileDescriptors,
 				Options:      protoOptions,
 			},
 		}, nil
@@ -206,8 +210,8 @@ func (r *request) toProtos() ([]*checkv1.CheckRequest, error) {
 		checkRequests = append(
 			checkRequests,
 			&checkv1.CheckRequest{
-				Files:        protoFiles,
-				AgainstFiles: protoAgainstFiles,
+				Files:        protoFileDescriptors,
+				AgainstFiles: protoAgainstFileDescriptors,
 				Options:      protoOptions,
 				RuleIds:      r.ruleIDs[start:end],
 			},
@@ -218,10 +222,27 @@ func (r *request) toProtos() ([]*checkv1.CheckRequest, error) {
 
 func (*request) isRequest() {}
 
+func validateFileDescriptors(fileDescriptors []descriptor.FileDescriptor) error {
+	_, err := fileNameToFileDescriptorForFileDescriptors(fileDescriptors)
+	return err
+}
+
+func fileNameToFileDescriptorForFileDescriptors(fileDescriptors []descriptor.FileDescriptor) (map[string]descriptor.FileDescriptor, error) {
+	fileNameToFileDescriptor := make(map[string]descriptor.FileDescriptor, len(fileDescriptors))
+	for _, fileDescriptor := range fileDescriptors {
+		fileName := fileDescriptor.Protoreflect().Path()
+		if _, ok := fileNameToFileDescriptor[fileName]; ok {
+			return nil, fmt.Errorf("duplicate file name: %q", fileName)
+		}
+		fileNameToFileDescriptor[fileName] = fileDescriptor
+	}
+	return fileNameToFileDescriptor, nil
+}
+
 type requestOptions struct {
-	againstFiles []File
-	options      Options
-	ruleIDs      []string
+	againstFileDescriptors []descriptor.FileDescriptor
+	options                Options
+	ruleIDs                []string
 }
 
 func newRequestOptions() *requestOptions {

--- a/check/request.go
+++ b/check/request.go
@@ -231,7 +231,7 @@ func validateFileDescriptors(fileDescriptors []descriptor.FileDescriptor) error 
 func fileNameToFileDescriptorForFileDescriptors(fileDescriptors []descriptor.FileDescriptor) (map[string]descriptor.FileDescriptor, error) {
 	fileNameToFileDescriptor := make(map[string]descriptor.FileDescriptor, len(fileDescriptors))
 	for _, fileDescriptor := range fileDescriptors {
-		fileName := fileDescriptor.Protoreflect().Path()
+		fileName := fileDescriptor.ProtoreflectFileDescriptor().Path()
 		if _, ok := fileNameToFileDescriptor[fileName]; ok {
 			return nil, fmt.Errorf("duplicate file name: %q", fileName)
 		}

--- a/check/response_writer.go
+++ b/check/response_writer.go
@@ -315,20 +315,20 @@ func validateAddAnnotationOptions(addAnnotationOptions *addAnnotationOptions) er
 
 func getFileLocationForAddAnnotationOptions(
 	fileNameToFileDescriptor map[string]descriptor.FileDescriptor,
-	descriptor protoreflect.Descriptor,
+	protoreflectDescriptor protoreflect.Descriptor,
 	fileName string,
 	path protoreflect.SourcePath,
 ) (descriptor.FileLocation, error) {
-	if descriptor != nil {
+	if protoreflectDescriptor != nil {
 		// Technically, ParentFile() can be nil.
-		if protoreflectFileDescriptor := descriptor.ParentFile(); protoreflectFileDescriptor != nil {
+		if protoreflectFileDescriptor := protoreflectDescriptor.ParentFile(); protoreflectFileDescriptor != nil {
 			fileDescriptor, ok := fileNameToFileDescriptor[protoreflectFileDescriptor.Path()]
 			if !ok {
 				return nil, fmt.Errorf("cannot add annotation for unknown file: %q", protoreflectFileDescriptor.Path())
 			}
-			return newLocation(
+			return descriptor.NewFileLocation(
 				fileDescriptor,
-				protoreflectFileDescriptor.SourceLocations().ByDescriptor(descriptor),
+				protoreflectFileDescriptor.SourceLocations().ByDescriptor(protoreflectDescriptor),
 			), nil
 		}
 		return nil, nil
@@ -342,7 +342,7 @@ func getFileLocationForAddAnnotationOptions(
 		if len(path) > 0 {
 			sourceLocation = fileDescriptor.Protoreflect().SourceLocations().ByPath(path)
 		}
-		return newLocation(fileDescriptor, sourceLocation), nil
+		return descriptor.NewFileLocation(fileDescriptor, sourceLocation), nil
 	}
 	return nil, nil
 }

--- a/check/response_writer.go
+++ b/check/response_writer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	"buf.build/go/bufplugin/descriptor"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -158,8 +159,8 @@ func WithAgainstFileNameAndSourcePath(againstFileName string, againstSourcePath 
 //
 // multiResponseWriter is used by checkClients and checkServiceHandlers.
 type multiResponseWriter struct {
-	fileNameToFile        map[string]File
-	againstFileNameToFile map[string]File
+	fileNameToFileDescriptor        map[string]descriptor.FileDescriptor
+	againstFileNameToFileDescriptor map[string]descriptor.FileDescriptor
 
 	annotations []Annotation
 	written     bool
@@ -168,17 +169,17 @@ type multiResponseWriter struct {
 }
 
 func newMultiResponseWriter(request Request) (*multiResponseWriter, error) {
-	fileNameToFile, err := fileNameToFileForFiles(request.Files())
+	fileNameToFileDescriptor, err := fileNameToFileDescriptorForFileDescriptors(request.FileDescriptors())
 	if err != nil {
 		return nil, err
 	}
-	againstFileNameToFile, err := fileNameToFileForFiles(request.AgainstFiles())
+	againstFileNameToFileDescriptor, err := fileNameToFileDescriptorForFileDescriptors(request.AgainstFileDescriptors())
 	if err != nil {
 		return nil, err
 	}
 	return &multiResponseWriter{
-		fileNameToFile:        fileNameToFile,
-		againstFileNameToFile: againstFileNameToFile,
+		fileNameToFileDescriptor:        fileNameToFileDescriptor,
+		againstFileNameToFileDescriptor: againstFileNameToFileDescriptor,
 	}, nil
 }
 
@@ -208,8 +209,8 @@ func (m *multiResponseWriter) addAnnotation(
 		return
 	}
 
-	location, err := getLocationForAddAnnotationOptions(
-		m.fileNameToFile,
+	fileLocation, err := getFileLocationForAddAnnotationOptions(
+		m.fileNameToFileDescriptor,
 		addAnnotationOptions.descriptor,
 		addAnnotationOptions.fileName,
 		addAnnotationOptions.sourcePath,
@@ -218,8 +219,8 @@ func (m *multiResponseWriter) addAnnotation(
 		m.errs = append(m.errs, err)
 		return
 	}
-	againstLocation, err := getLocationForAddAnnotationOptions(
-		m.againstFileNameToFile,
+	againstFileLocation, err := getFileLocationForAddAnnotationOptions(
+		m.againstFileNameToFileDescriptor,
 		addAnnotationOptions.againstDescriptor,
 		addAnnotationOptions.againstFileName,
 		addAnnotationOptions.againstSourcePath,
@@ -231,8 +232,8 @@ func (m *multiResponseWriter) addAnnotation(
 	annotation, err := newAnnotation(
 		ruleID,
 		addAnnotationOptions.message,
-		location,
-		againstLocation,
+		fileLocation,
+		againstFileLocation,
 	)
 	if err != nil {
 		m.errs = append(m.errs, err)
@@ -312,36 +313,36 @@ func validateAddAnnotationOptions(addAnnotationOptions *addAnnotationOptions) er
 	return nil
 }
 
-func getLocationForAddAnnotationOptions(
-	fileNameToFile map[string]File,
+func getFileLocationForAddAnnotationOptions(
+	fileNameToFileDescriptor map[string]descriptor.FileDescriptor,
 	descriptor protoreflect.Descriptor,
 	fileName string,
 	path protoreflect.SourcePath,
-) (Location, error) {
+) (descriptor.FileLocation, error) {
 	if descriptor != nil {
 		// Technically, ParentFile() can be nil.
-		if fileDescriptor := descriptor.ParentFile(); fileDescriptor != nil {
-			file, ok := fileNameToFile[fileDescriptor.Path()]
+		if protoreflectFileDescriptor := descriptor.ParentFile(); protoreflectFileDescriptor != nil {
+			fileDescriptor, ok := fileNameToFileDescriptor[protoreflectFileDescriptor.Path()]
 			if !ok {
-				return nil, fmt.Errorf("cannot add annotation for unknown file: %q", fileDescriptor.Path())
+				return nil, fmt.Errorf("cannot add annotation for unknown file: %q", protoreflectFileDescriptor.Path())
 			}
 			return newLocation(
-				file,
-				fileDescriptor.SourceLocations().ByDescriptor(descriptor),
+				fileDescriptor,
+				protoreflectFileDescriptor.SourceLocations().ByDescriptor(descriptor),
 			), nil
 		}
 		return nil, nil
 	}
 	if fileName != "" {
 		var sourceLocation protoreflect.SourceLocation
-		file, ok := fileNameToFile[fileName]
+		fileDescriptor, ok := fileNameToFileDescriptor[fileName]
 		if !ok {
 			return nil, fmt.Errorf("cannot add annotation for unknown file: %q", fileName)
 		}
 		if len(path) > 0 {
-			sourceLocation = file.FileDescriptor().SourceLocations().ByPath(path)
+			sourceLocation = fileDescriptor.Protoreflect().SourceLocations().ByPath(path)
 		}
-		return newLocation(file, sourceLocation), nil
+		return newLocation(fileDescriptor, sourceLocation), nil
 	}
 	return nil, nil
 }

--- a/check/response_writer.go
+++ b/check/response_writer.go
@@ -340,7 +340,7 @@ func getFileLocationForAddAnnotationOptions(
 			return nil, fmt.Errorf("cannot add annotation for unknown file: %q", fileName)
 		}
 		if len(path) > 0 {
-			sourceLocation = fileDescriptor.Protoreflect().SourceLocations().ByPath(path)
+			sourceLocation = fileDescriptor.ProtoreflectFileDescriptor().SourceLocations().ByPath(path)
 		}
 		return descriptor.NewFileLocation(fileDescriptor, sourceLocation), nil
 	}

--- a/descriptor/compare.go
+++ b/descriptor/compare.go
@@ -32,7 +32,7 @@ func CompareFileLocations(one FileLocation, two FileLocation) int {
 	if one != nil && two == nil {
 		return 1
 	}
-	if compare := strings.Compare(one.FileDescriptor().Protoreflect().Path(), two.FileDescriptor().Protoreflect().Path()); compare != 0 {
+	if compare := strings.Compare(one.FileDescriptor().ProtoreflectFileDescriptor().Path(), two.FileDescriptor().ProtoreflectFileDescriptor().Path()); compare != 0 {
 		return compare
 	}
 	if compare := compare.CompareInts(one.StartLine(), two.StartLine()); compare != 0 {

--- a/descriptor/compare.go
+++ b/descriptor/compare.go
@@ -1,0 +1,60 @@
+// Copyright 2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package descriptor
+
+import (
+	"slices"
+	"strings"
+
+	"buf.build/go/bufplugin/internal/pkg/compare"
+)
+
+// CompareFileLocations returns -1 if one < two, 1 if one > two, 0 otherwise.
+func CompareFileLocations(one FileLocation, two FileLocation) int {
+	if one == nil && two == nil {
+		return 0
+	}
+	if one == nil && two != nil {
+		return -1
+	}
+	if one != nil && two == nil {
+		return 1
+	}
+	if compare := strings.Compare(one.FileDescriptor().Protoreflect().Path(), two.FileDescriptor().Protoreflect().Path()); compare != 0 {
+		return compare
+	}
+	if compare := compare.CompareInts(one.StartLine(), two.StartLine()); compare != 0 {
+		return compare
+	}
+	if compare := compare.CompareInts(one.StartColumn(), two.StartColumn()); compare != 0 {
+		return compare
+	}
+	if compare := compare.CompareInts(one.EndLine(), two.EndLine()); compare != 0 {
+		return compare
+	}
+	if compare := compare.CompareInts(one.EndColumn(), two.EndColumn()); compare != 0 {
+		return compare
+	}
+	if compare := slices.Compare(one.unclonedSourcePath(), two.unclonedSourcePath()); compare != 0 {
+		return compare
+	}
+	if compare := strings.Compare(one.LeadingComments(), two.LeadingComments()); compare != 0 {
+		return compare
+	}
+	if compare := strings.Compare(one.TrailingComments(), two.TrailingComments()); compare != 0 {
+		return compare
+	}
+	return slices.Compare(one.unclonedLeadingDetachedComments(), two.unclonedLeadingDetachedComments())
+}

--- a/descriptor/descriptor.go
+++ b/descriptor/descriptor.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package descriptor provides descriptor types.
+package descriptor // import "buf.build/go/bufplugin/descriptor"

--- a/descriptor/file_descriptor.go
+++ b/descriptor/file_descriptor.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"slices"
 
-	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
+	descriptorv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/descriptor/v1"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -65,17 +65,17 @@ type FileDescriptor interface {
 	UnusedDependencyIndexes() []int32
 
 	// ToProto converts the FileDescriptor to its Protobuf representation.
-	ToProto() *checkv1.File
+	ToProto() *descriptorv1.FileDescriptor
 
 	isFileDescriptor()
 }
 
-// FileDescriptorsForProtoFileDescriptors returns a new slice of FileDescriptors for the given checkv1.FileDescriptors.
-func FileDescriptorsForProtoFileDescriptors(protoFileDescriptors []*checkv1.File) ([]FileDescriptor, error) {
+// FileDescriptorsForProtoFileDescriptors returns a new slice of FileDescriptors for the given descriptorv1.FileDescriptorDescriptors.
+func FileDescriptorsForProtoFileDescriptors(protoFileDescriptors []*descriptorv1.FileDescriptor) ([]FileDescriptor, error) {
 	if len(protoFileDescriptors) == 0 {
 		return nil, nil
 	}
-	fileNameToProtoFileDescriptor := make(map[string]*checkv1.File, len(protoFileDescriptors))
+	fileNameToProtoFileDescriptor := make(map[string]*descriptorv1.FileDescriptor, len(protoFileDescriptors))
 	fileDescriptorProtos := make([]*descriptorpb.FileDescriptorProto, len(protoFileDescriptors))
 	for i, protoFileDescriptor := range protoFileDescriptors {
 		fileDescriptorProto := protoFileDescriptor.GetFileDescriptorProto()
@@ -177,11 +177,11 @@ func (f *fileDescriptor) UnusedDependencyIndexes() []int32 {
 	return slices.Clone(f.unusedDependencyIndexes)
 }
 
-func (f *fileDescriptor) ToProto() *checkv1.File {
+func (f *fileDescriptor) ToProto() *descriptorv1.FileDescriptor {
 	if f == nil {
 		return nil
 	}
-	return &checkv1.File{
+	return &descriptorv1.FileDescriptor{
 		FileDescriptorProto: f.fileDescriptorProto,
 		IsImport:            f.isImport,
 		IsSyntaxUnspecified: f.isSyntaxUnspecified,

--- a/descriptor/file_descriptor.go
+++ b/descriptor/file_descriptor.go
@@ -29,10 +29,10 @@ import (
 // The raw FileDescriptorProto is also provided from this interface.
 // are provided.
 type FileDescriptor interface {
-	// Protoreflect returns the protoreflect FileDescriptor representing this File.
+	// ProtoreflectFileDescriptor returns the protoreflect.FileDescriptor representing this FileDescriptor.
 	//
 	// This will always contain SourceCodeInfo.
-	Protoreflect() protoreflect.FileDescriptor
+	ProtoreflectFileDescriptor() protoreflect.FileDescriptor
 
 	// FileDescriptorProto returns the FileDescriptorProto representing this File.
 	//
@@ -157,7 +157,7 @@ func newFileDescriptor(
 	}
 }
 
-func (f *fileDescriptor) Protoreflect() protoreflect.FileDescriptor {
+func (f *fileDescriptor) ProtoreflectFileDescriptor() protoreflect.FileDescriptor {
 	return f.protoreflectFileDescriptor
 }
 

--- a/descriptor/file_descriptor.go
+++ b/descriptor/file_descriptor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package check
+package descriptor
 
 import (
 	"fmt"
@@ -24,17 +24,16 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
-// File is an invidual file that should be checked.
+// FileDescriptor is a protoreflect.FileDescriptor with additional properties.
 //
-// Both the protoreflect FileDescriptor and the raw FileDescriptorProto interacves
+// The raw FileDescriptorProto is also provided from this interface.
 // are provided.
-//
-// Files also have the property of being imports or non-imports.
-type File interface {
-	// FileDescriptor returns the protoreflect FileDescriptor representing this File.
+type FileDescriptor interface {
+	// Protoreflect returns the protoreflect FileDescriptor representing this File.
 	//
 	// This will always contain SourceCodeInfo.
-	FileDescriptor() protoreflect.FileDescriptor
+	Protoreflect() protoreflect.FileDescriptor
+
 	// FileDescriptorProto returns the FileDescriptorProto representing this File.
 	//
 	// This is not a copy - do not modify!
@@ -65,27 +64,28 @@ type File interface {
 	// This matches the shape of the PublicDependency and WeakDependency fields.
 	UnusedDependencyIndexes() []int32
 
-	toProto() *checkv1.File
+	// ToProto converts the FileDescriptor to its Protobuf representation.
+	ToProto() *checkv1.File
 
-	isFile()
+	isFileDescriptor()
 }
 
-// FilesForProtoFiles returns a new slice of Files for the given checkv1.Files.
-func FilesForProtoFiles(protoFiles []*checkv1.File) ([]File, error) {
-	if len(protoFiles) == 0 {
+// FileDescriptorsForProtoFileDescriptors returns a new slice of FileDescriptors for the given checkv1.FileDescriptors.
+func FileDescriptorsForProtoFileDescriptors(protoFileDescriptors []*checkv1.File) ([]FileDescriptor, error) {
+	if len(protoFileDescriptors) == 0 {
 		return nil, nil
 	}
-	fileNameToProtoFile := make(map[string]*checkv1.File, len(protoFiles))
-	fileDescriptorProtos := make([]*descriptorpb.FileDescriptorProto, len(protoFiles))
-	for i, protoFile := range protoFiles {
-		fileDescriptorProto := protoFile.GetFileDescriptorProto()
+	fileNameToProtoFileDescriptor := make(map[string]*checkv1.File, len(protoFileDescriptors))
+	fileDescriptorProtos := make([]*descriptorpb.FileDescriptorProto, len(protoFileDescriptors))
+	for i, protoFileDescriptor := range protoFileDescriptors {
+		fileDescriptorProto := protoFileDescriptor.GetFileDescriptorProto()
 		fileName := fileDescriptorProto.GetName()
-		if _, ok := fileNameToProtoFile[fileName]; ok {
+		if _, ok := fileNameToProtoFileDescriptor[fileName]; ok {
 			//  This should have been validated via protovalidate.
 			return nil, fmt.Errorf("duplicate file name: %q", fileName)
 		}
 		fileDescriptorProtos[i] = fileDescriptorProto
-		fileNameToProtoFile[fileName] = protoFile
+		fileNameToProtoFileDescriptor[fileName] = protoFileDescriptor
 	}
 
 	protoregistryFiles, err := protodesc.NewFiles(
@@ -97,24 +97,24 @@ func FilesForProtoFiles(protoFiles []*checkv1.File) ([]File, error) {
 		return nil, err
 	}
 
-	files := make([]File, 0, len(protoFiles))
+	fileDescriptors := make([]FileDescriptor, 0, len(protoFileDescriptors))
 	protoregistryFiles.RangeFiles(
-		func(fileDescriptor protoreflect.FileDescriptor) bool {
-			protoFile, ok := fileNameToProtoFile[fileDescriptor.Path()]
+		func(protoreflectFileDescriptor protoreflect.FileDescriptor) bool {
+			protoFileDescriptor, ok := fileNameToProtoFileDescriptor[protoreflectFileDescriptor.Path()]
 			if !ok {
 				// If the protoreflect API is sane, this should never happen.
 				// However, the protoreflect API is not sane.
-				err = fmt.Errorf("unknown file: %q", fileDescriptor.Path())
+				err = fmt.Errorf("unknown file: %q", protoreflectFileDescriptor.Path())
 				return false
 			}
-			files = append(
-				files,
-				newFile(
-					fileDescriptor,
-					protoFile.GetFileDescriptorProto(),
-					protoFile.GetIsImport(),
-					protoFile.GetIsSyntaxUnspecified(),
-					protoFile.GetUnusedDependency(),
+			fileDescriptors = append(
+				fileDescriptors,
+				newFileDescriptor(
+					protoreflectFileDescriptor,
+					protoFileDescriptor.GetFileDescriptorProto(),
+					protoFileDescriptor.GetIsImport(),
+					protoFileDescriptor.GetIsSyntaxUnspecified(),
+					protoFileDescriptor.GetUnusedDependency(),
 				),
 			)
 			return true
@@ -123,61 +123,64 @@ func FilesForProtoFiles(protoFiles []*checkv1.File) ([]File, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(files) != len(protoFiles) {
+	if len(fileDescriptors) != len(protoFileDescriptors) {
 		// If the protoreflect API is sane, this should never happen.
 		// However, the protoreflect API is not sane.
-		return nil, fmt.Errorf("expected %d files from protoregistry, got %d", len(protoFiles), len(files))
+		return nil, fmt.Errorf("expected %d files from protoregistry, got %d", len(protoFileDescriptors), len(fileDescriptors))
 	}
-	return files, nil
+	return fileDescriptors, nil
 }
 
 // *** PRIVATE ***
 
-type file struct {
-	fileDescriptor          protoreflect.FileDescriptor
-	fileDescriptorProto     *descriptorpb.FileDescriptorProto
-	isImport                bool
-	isSyntaxUnspecified     bool
-	unusedDependencyIndexes []int32
+type fileDescriptor struct {
+	protoreflectFileDescriptor protoreflect.FileDescriptor
+	fileDescriptorProto        *descriptorpb.FileDescriptorProto
+	isImport                   bool
+	isSyntaxUnspecified        bool
+	unusedDependencyIndexes    []int32
 }
 
-func newFile(
-	fileDescriptor protoreflect.FileDescriptor,
+func newFileDescriptor(
+	protoreflectFileDescriptor protoreflect.FileDescriptor,
 	fileDescriptorProto *descriptorpb.FileDescriptorProto,
 	isImport bool,
 	isSyntaxUnspecified bool,
 	unusedDependencyIndexes []int32,
-) *file {
-	return &file{
-		fileDescriptor:          fileDescriptor,
-		fileDescriptorProto:     fileDescriptorProto,
-		isImport:                isImport,
-		isSyntaxUnspecified:     isSyntaxUnspecified,
-		unusedDependencyIndexes: unusedDependencyIndexes,
+) *fileDescriptor {
+	return &fileDescriptor{
+		protoreflectFileDescriptor: protoreflectFileDescriptor,
+		fileDescriptorProto:        fileDescriptorProto,
+		isImport:                   isImport,
+		isSyntaxUnspecified:        isSyntaxUnspecified,
+		unusedDependencyIndexes:    unusedDependencyIndexes,
 	}
 }
 
-func (f *file) FileDescriptor() protoreflect.FileDescriptor {
-	return f.fileDescriptor
+func (f *fileDescriptor) Protoreflect() protoreflect.FileDescriptor {
+	return f.protoreflectFileDescriptor
 }
 
-func (f *file) FileDescriptorProto() *descriptorpb.FileDescriptorProto {
+func (f *fileDescriptor) FileDescriptorProto() *descriptorpb.FileDescriptorProto {
 	return f.fileDescriptorProto
 }
 
-func (f *file) IsImport() bool {
+func (f *fileDescriptor) IsImport() bool {
 	return f.isImport
 }
 
-func (f *file) IsSyntaxUnspecified() bool {
+func (f *fileDescriptor) IsSyntaxUnspecified() bool {
 	return f.isSyntaxUnspecified
 }
 
-func (f *file) UnusedDependencyIndexes() []int32 {
+func (f *fileDescriptor) UnusedDependencyIndexes() []int32 {
 	return slices.Clone(f.unusedDependencyIndexes)
 }
 
-func (f *file) toProto() *checkv1.File {
+func (f *fileDescriptor) ToProto() *checkv1.File {
+	if f == nil {
+		return nil
+	}
 	return &checkv1.File{
 		FileDescriptorProto: f.fileDescriptorProto,
 		IsImport:            f.isImport,
@@ -186,21 +189,4 @@ func (f *file) toProto() *checkv1.File {
 	}
 }
 
-func (*file) isFile() {}
-
-func validateFiles(files []File) error {
-	_, err := fileNameToFileForFiles(files)
-	return err
-}
-
-func fileNameToFileForFiles(files []File) (map[string]File, error) {
-	fileNameToFile := make(map[string]File, len(files))
-	for _, file := range files {
-		fileName := file.FileDescriptor().Path()
-		if _, ok := fileNameToFile[fileName]; ok {
-			return nil, fmt.Errorf("duplicate file name: %q", fileName)
-		}
-		fileNameToFile[fileName] = file
-	}
-	return fileNameToFile, nil
-}
+func (*fileDescriptor) isFileDescriptor() {}

--- a/descriptor/file_location.go
+++ b/descriptor/file_location.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package check
+package descriptor
 
 import (
 	"slices"
@@ -21,15 +21,15 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// Location is a reference to a File or to a location within a File.
+// FileLocation is a reference to a FileDescriptor or to a location within a FileDescriptor.
 //
-// A Location always has a file name.
-type Location interface {
-	// File is the File associated with the Location.
+// A FileLocation always has a file name.
+type FileLocation interface {
+	// FileDescriptor is the FileDescriptor associated with the FileLocation.
 	//
 	// Always present.
-	File() File
-	// SourcePath returns the path within the FileDescriptorProto of the Location.
+	FileDescriptor() FileDescriptor
+	// SourcePath returns the path within the FileDescriptorProto of the FileLocation.
 	SourcePath() protoreflect.SourcePath
 
 	// StartLine returns the zero-indexed start line, if known.
@@ -46,83 +46,84 @@ type Location interface {
 	TrailingComments() string
 	// LeadingDetachedComments returns any leading detached comments, if known.
 	LeadingDetachedComments() []string
+	// ToProto converts the FileLocation to its Protobuf representation.
+	ToProto() *checkv1.Location
 
 	unclonedSourcePath() protoreflect.SourcePath
 	unclonedLeadingDetachedComments() []string
-	toProto() *checkv1.Location
 
-	isLocation()
+	isFileLocation()
 }
 
 // *** PRIVATE ***
 
-type location struct {
-	file           File
+type fileLocation struct {
+	fileDescriptor FileDescriptor
 	sourceLocation protoreflect.SourceLocation
 }
 
-func newLocation(
-	file File,
+func newFileLocation(
+	fileDescriptor FileDescriptor,
 	sourceLocation protoreflect.SourceLocation,
-) *location {
-	return &location{
-		file:           file,
+) *fileLocation {
+	return &fileLocation{
+		fileDescriptor: fileDescriptor,
 		sourceLocation: sourceLocation,
 	}
 }
 
-func (l *location) File() File {
-	return l.file
+func (l *fileLocation) FileDescriptor() FileDescriptor {
+	return l.fileDescriptor
 }
 
-func (l *location) SourcePath() protoreflect.SourcePath {
+func (l *fileLocation) SourcePath() protoreflect.SourcePath {
 	return slices.Clone(l.sourceLocation.Path)
 }
 
-func (l *location) StartLine() int {
+func (l *fileLocation) StartLine() int {
 	return l.sourceLocation.StartLine
 }
 
-func (l *location) StartColumn() int {
+func (l *fileLocation) StartColumn() int {
 	return l.sourceLocation.StartColumn
 }
 
-func (l *location) EndLine() int {
+func (l *fileLocation) EndLine() int {
 	return l.sourceLocation.EndLine
 }
 
-func (l *location) EndColumn() int {
+func (l *fileLocation) EndColumn() int {
 	return l.sourceLocation.EndColumn
 }
 
-func (l *location) LeadingComments() string {
+func (l *fileLocation) LeadingComments() string {
 	return l.sourceLocation.LeadingComments
 }
 
-func (l *location) TrailingComments() string {
+func (l *fileLocation) TrailingComments() string {
 	return l.sourceLocation.TrailingComments
 }
 
-func (l *location) LeadingDetachedComments() []string {
+func (l *fileLocation) LeadingDetachedComments() []string {
 	return slices.Clone(l.sourceLocation.LeadingDetachedComments)
 }
 
-func (l *location) unclonedSourcePath() protoreflect.SourcePath {
-	return l.sourceLocation.Path
-}
-
-func (l *location) unclonedLeadingDetachedComments() []string {
-	return l.sourceLocation.LeadingDetachedComments
-}
-
-func (l *location) toProto() *checkv1.Location {
+func (l *fileLocation) ToProto() *checkv1.Location {
 	if l == nil {
 		return nil
 	}
 	return &checkv1.Location{
-		FileName:   l.file.FileDescriptor().Path(),
+		FileName:   l.fileDescriptor.Protoreflect().Path(),
 		SourcePath: l.sourceLocation.Path,
 	}
 }
 
-func (*location) isLocation() {}
+func (l *fileLocation) unclonedSourcePath() protoreflect.SourcePath {
+	return l.sourceLocation.Path
+}
+
+func (l *fileLocation) unclonedLeadingDetachedComments() []string {
+	return l.sourceLocation.LeadingDetachedComments
+}
+
+func (*fileLocation) isFileLocation() {}

--- a/descriptor/file_location.go
+++ b/descriptor/file_location.go
@@ -114,7 +114,7 @@ func (l *fileLocation) ToProto() *descriptorv1.FileLocation {
 		return nil
 	}
 	return &descriptorv1.FileLocation{
-		FileName:   l.fileDescriptor.Protoreflect().Path(),
+		FileName:   l.fileDescriptor.ProtoreflectFileDescriptor().Path(),
 		SourcePath: l.sourceLocation.Path,
 	}
 }

--- a/descriptor/file_location.go
+++ b/descriptor/file_location.go
@@ -55,21 +55,22 @@ type FileLocation interface {
 	isFileLocation()
 }
 
+// NewFileLocation returns a new FileLocation.
+func NewFileLocation(
+	fileDescriptor FileDescriptor,
+	sourceLocation protoreflect.SourceLocation,
+) FileLocation {
+	return &fileLocation{
+		fileDescriptor: fileDescriptor,
+		sourceLocation: sourceLocation,
+	}
+}
+
 // *** PRIVATE ***
 
 type fileLocation struct {
 	fileDescriptor FileDescriptor
 	sourceLocation protoreflect.SourceLocation
-}
-
-func newFileLocation(
-	fileDescriptor FileDescriptor,
-	sourceLocation protoreflect.SourceLocation,
-) *fileLocation {
-	return &fileLocation{
-		fileDescriptor: fileDescriptor,
-		sourceLocation: sourceLocation,
-	}
 }
 
 func (l *fileLocation) FileDescriptor() FileDescriptor {

--- a/descriptor/file_location.go
+++ b/descriptor/file_location.go
@@ -17,7 +17,7 @@ package descriptor
 import (
 	"slices"
 
-	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
+	descriptorv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/descriptor/v1"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -47,7 +47,7 @@ type FileLocation interface {
 	// LeadingDetachedComments returns any leading detached comments, if known.
 	LeadingDetachedComments() []string
 	// ToProto converts the FileLocation to its Protobuf representation.
-	ToProto() *checkv1.Location
+	ToProto() *descriptorv1.FileLocation
 
 	unclonedSourcePath() protoreflect.SourcePath
 	unclonedLeadingDetachedComments() []string
@@ -109,11 +109,11 @@ func (l *fileLocation) LeadingDetachedComments() []string {
 	return slices.Clone(l.sourceLocation.LeadingDetachedComments)
 }
 
-func (l *fileLocation) ToProto() *checkv1.Location {
+func (l *fileLocation) ToProto() *descriptorv1.FileLocation {
 	if l == nil {
 		return nil
 	}
-	return &checkv1.Location{
+	return &descriptorv1.FileLocation{
 		FileName:   l.fileDescriptor.Protoreflect().Path(),
 		SourcePath: l.sourceLocation.Path,
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.23.0
 
 require (
-	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-00000000000000-9761ea6a8cee.2
+	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240920185553-cf97df2825f6.2
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/bufbuild/protovalidate-go v0.6.5
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.23.0
 
 require (
-	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240904181154-a0be11449112.2
+	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-00000000000000-9761ea6a8cee.2
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/bufbuild/protovalidate-go v0.6.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-00000000000000-9761ea6a8cee.2 h1:saqQcA0XF8LL9vE7OvN1CDPQYy4M8oWU+0C1O8eh/cU=
+buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-00000000000000-9761ea6a8cee.2/go.mod h1:B+9TKHRYqoAUW57pLjhkLOnBCu0DQYMV+f7imQ9nXwI=
 buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240904181154-a0be11449112.2 h1:X9qBPcvWGOJs/CeRVLoxxLJwC/eKyWDS/G4nj+3KGMY=
 buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240904181154-a0be11449112.2/go.mod h1:B+9TKHRYqoAUW57pLjhkLOnBCu0DQYMV+f7imQ9nXwI=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.2-20240717164558-a6c49f84cc0f.2 h1:SZRVx928rbYZ6hEKUIN+vtGDkl7uotABRWGY4OAg5gM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-00000000000000-9761ea6a8cee.2 h1:saqQcA0XF8LL9vE7OvN1CDPQYy4M8oWU+0C1O8eh/cU=
-buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-00000000000000-9761ea6a8cee.2/go.mod h1:B+9TKHRYqoAUW57pLjhkLOnBCu0DQYMV+f7imQ9nXwI=
-buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240904181154-a0be11449112.2 h1:X9qBPcvWGOJs/CeRVLoxxLJwC/eKyWDS/G4nj+3KGMY=
-buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240904181154-a0be11449112.2/go.mod h1:B+9TKHRYqoAUW57pLjhkLOnBCu0DQYMV+f7imQ9nXwI=
+buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240920185553-cf97df2825f6.2 h1:dM/jKJP5298DVmmet50pEaREQY1ZleguYDrpUWwl6AA=
+buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.34.2-20240920185553-cf97df2825f6.2/go.mod h1:B+9TKHRYqoAUW57pLjhkLOnBCu0DQYMV+f7imQ9nXwI=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.2-20240717164558-a6c49f84cc0f.2 h1:SZRVx928rbYZ6hEKUIN+vtGDkl7uotABRWGY4OAg5gM=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.2-20240717164558-a6c49f84cc0f.2/go.mod h1:ylS4c28ACSI59oJrOdW4pHS4n0Hw4TgSPHn8rpHl4Yw=
 buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.34.2-20240828222655-5345c0a56177.2 h1:oSi+Adw4xvIjXrW8eY8QGR3sBdfWeY5HN/RefnRt52M=

--- a/internal/gen/buf/plugin/check/v1/v1pluginrpc/check_service.pluginrpc.go
+++ b/internal/gen/buf/plugin/check/v1/v1pluginrpc/check_service.pluginrpc.go
@@ -71,7 +71,7 @@ func (s CheckServiceSpecBuilder) Build() (pluginrpc.Spec, error) {
 
 // CheckServiceClient is a client for the buf.plugin.check.v1.CheckService service.
 type CheckServiceClient interface {
-	// Check a set of Files for failures.
+	// Check a set of FileDescriptors for failures.
 	//
 	// All Annotations returned will have an ID that is contained within a Rule listed by ListRules.
 	Check(context.Context, *v1.CheckRequest, ...pluginrpc.CallOption) (*v1.CheckResponse, error)
@@ -90,7 +90,7 @@ func NewCheckServiceClient(client pluginrpc.Client) (CheckServiceClient, error) 
 
 // CheckServiceHandler is an implementation of the buf.plugin.check.v1.CheckService service.
 type CheckServiceHandler interface {
-	// Check a set of Files for failures.
+	// Check a set of FileDescriptors for failures.
 	//
 	// All Annotations returned will have an ID that is contained within a Rule listed by ListRules.
 	Check(context.Context, *v1.CheckRequest) (*v1.CheckResponse, error)
@@ -102,7 +102,7 @@ type CheckServiceHandler interface {
 
 // CheckServiceServer serves the buf.plugin.check.v1.CheckService service.
 type CheckServiceServer interface {
-	// Check a set of Files for failures.
+	// Check a set of FileDescriptors for failures.
 	//
 	// All Annotations returned will have an ID that is contained within a Rule listed by ListRules.
 	Check(context.Context, pluginrpc.HandleEnv, ...pluginrpc.HandleOption) error

--- a/internal/pkg/compare/compare.go
+++ b/internal/pkg/compare/compare.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare
+
+// CompareInts returns -1 if one < two, 1 if one > two, 0 otherwise.
+func CompareInts(one int, two int) int {
+	if one < two {
+		return -1
+	}
+	if one > two {
+		return 1
+	}
+	return 0
+}

--- a/option/errors.go
+++ b/option/errors.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import (
+	"fmt"
+	"strings"
+)
+
+type unexpectedOptionValueTypeError struct {
+	key      string
+	expected any
+	actual   any
+}
+
+func newUnexpectedOptionValueTypeError(key string, expected any, actual any) *unexpectedOptionValueTypeError {
+	return &unexpectedOptionValueTypeError{
+		key:      key,
+		expected: expected,
+		actual:   actual,
+	}
+}
+
+func (u *unexpectedOptionValueTypeError) Error() string {
+	if u == nil {
+		return ""
+	}
+	var sb strings.Builder
+	_, _ = sb.WriteString(`unexpected type for option value "`)
+	_, _ = sb.WriteString(u.key)
+	_, _ = sb.WriteString(fmt.Sprintf(`": expected %T, got %T`, u.expected, u.actual))
+	return sb.String()
+}

--- a/option/option.go
+++ b/option/option.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package option provides the Options type for plugins.
+package option // import "buf.build/go/bufplugin/option"

--- a/option/options.go
+++ b/option/options.go
@@ -21,7 +21,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package check
+package option
 
 import (
 	"errors"
@@ -31,7 +31,8 @@ import (
 	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
 )
 
-var emptyOptions = newOptionsNoValidate(nil)
+// EmptyOptions is an instance of Options with no keys.
+var EmptyOptions = newOptionsNoValidate(nil)
 
 // Options are key/values that can control the behavior of a RuleHandler,
 // and can control the value of the Purpose string of the Rule.
@@ -67,7 +68,8 @@ type Options interface {
 	// The range order is not deterministic.
 	Range(f func(key string, value any))
 
-	toProto() ([]*checkv1.Option, error)
+	// ToProto converts the Options to its Protobuf representation.
+	ToProto() ([]*checkv1.Option, error)
 
 	isOption()
 }
@@ -239,7 +241,7 @@ func (o *options) Range(f func(key string, value any)) {
 	}
 }
 
-func (o *options) toProto() ([]*checkv1.Option, error) {
+func (o *options) ToProto() ([]*checkv1.Option, error) {
 	if o == nil {
 		return nil, nil
 	}

--- a/option/options.go
+++ b/option/options.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"reflect"
 
-	checkv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/check/v1"
+	optionv1 "buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go/buf/plugin/option/v1"
 )
 
 // EmptyOptions is an instance of Options with no keys.
@@ -69,7 +69,7 @@ type Options interface {
 	Range(f func(key string, value any))
 
 	// ToProto converts the Options to its Protobuf representation.
-	ToProto() ([]*checkv1.Option, error)
+	ToProto() ([]*optionv1.Option, error)
 
 	isOption()
 }
@@ -82,8 +82,8 @@ func NewOptions(keyToValue map[string]any) (Options, error) {
 	return newOptionsNoValidate(keyToValue), nil
 }
 
-// OptionsForProtoOptions returns a new Options for the given checkv1.Options.
-func OptionsForProtoOptions(protoOptions []*checkv1.Option) (Options, error) {
+// OptionsForProtoOptions returns a new Options for the given optionv1.Options.
+func OptionsForProtoOptions(protoOptions []*optionv1.Option) (Options, error) {
 	keyToValue := make(map[string]any, len(protoOptions))
 	for _, protoOption := range protoOptions {
 		value, err := protoValueToValue(protoOption.GetValue())
@@ -241,11 +241,11 @@ func (o *options) Range(f func(key string, value any)) {
 	}
 }
 
-func (o *options) ToProto() ([]*checkv1.Option, error) {
+func (o *options) ToProto() ([]*optionv1.Option, error) {
 	if o == nil {
 		return nil, nil
 	}
-	protoOptions := make([]*checkv1.Option, 0, len(o.keyToValue))
+	protoOptions := make([]*optionv1.Option, 0, len(o.keyToValue))
 	for key, value := range o.keyToValue {
 		protoValue, err := valueToProtoValue(value)
 		if err != nil {
@@ -254,7 +254,7 @@ func (o *options) ToProto() ([]*checkv1.Option, error) {
 		// Assuming that we've validated that no values are empty.
 		protoOptions = append(
 			protoOptions,
-			&checkv1.Option{
+			&optionv1.Option{
 				Key:   key,
 				Value: protoValue,
 			},
@@ -266,41 +266,41 @@ func (o *options) ToProto() ([]*checkv1.Option, error) {
 func (*options) isOption() {}
 
 // You can assume that value is a valid value.
-func valueToProtoValue(value any) (*checkv1.Value, error) {
+func valueToProtoValue(value any) (*optionv1.Value, error) {
 	switch reflectValue := reflect.ValueOf(value); reflectValue.Kind() {
 	case reflect.Bool:
-		return &checkv1.Value{
-			Type: &checkv1.Value_BoolValue{
+		return &optionv1.Value{
+			Type: &optionv1.Value_BoolValue{
 				BoolValue: reflectValue.Bool(),
 			},
 		}, nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return &checkv1.Value{
-			Type: &checkv1.Value_Int64Value{
+		return &optionv1.Value{
+			Type: &optionv1.Value_Int64Value{
 				Int64Value: reflectValue.Int(),
 			},
 		}, nil
 	case reflect.Float32, reflect.Float64:
-		return &checkv1.Value{
-			Type: &checkv1.Value_DoubleValue{
+		return &optionv1.Value{
+			Type: &optionv1.Value_DoubleValue{
 				DoubleValue: reflectValue.Float(),
 			},
 		}, nil
 	case reflect.String:
-		return &checkv1.Value{
-			Type: &checkv1.Value_StringValue{
+		return &optionv1.Value{
+			Type: &optionv1.Value_StringValue{
 				StringValue: reflectValue.String(),
 			},
 		}, nil
 	case reflect.Slice:
 		if t, ok := value.([]byte); ok {
-			return &checkv1.Value{
-				Type: &checkv1.Value_BytesValue{
+			return &optionv1.Value{
+				Type: &optionv1.Value_BytesValue{
 					BytesValue: t,
 				},
 			}, nil
 		}
-		values := make([]*checkv1.Value, reflectValue.Len())
+		values := make([]*optionv1.Value, reflectValue.Len())
 		for i := 0; i < reflectValue.Len(); i++ {
 			subValue, err := valueToProtoValue(reflectValue.Index(i).Interface())
 			if err != nil {
@@ -308,9 +308,9 @@ func valueToProtoValue(value any) (*checkv1.Value, error) {
 			}
 			values[i] = subValue
 		}
-		return &checkv1.Value{
-			Type: &checkv1.Value_ListValue{
-				ListValue: &checkv1.ListValue{
+		return &optionv1.Value{
+			Type: &optionv1.Value_ListValue{
+				ListValue: &optionv1.ListValue{
 					Values: values,
 				},
 			},
@@ -322,9 +322,9 @@ func valueToProtoValue(value any) (*checkv1.Value, error) {
 	}
 }
 
-func protoValueToValue(protoValue *checkv1.Value) (any, error) {
+func protoValueToValue(protoValue *optionv1.Value) (any, error) {
 	if protoValue == nil {
-		return nil, errors.New("invalid checkv1.Value: value cannot be nil")
+		return nil, errors.New("invalid optionv1.Value: value cannot be nil")
 	}
 	switch {
 	case protoValue.GetBoolValue():
@@ -341,7 +341,7 @@ func protoValueToValue(protoValue *checkv1.Value) (any, error) {
 		protoListValue := protoValue.GetListValue()
 		protoListValues := protoListValue.GetValues()
 		if len(protoListValues) == 0 {
-			return nil, errors.New("invalid checkv1.Value: list_values had no values")
+			return nil, errors.New("invalid optionv1.Value: list_values had no values")
 		}
 		anySlice := make([]any, len(protoListValue.GetValues()))
 		for i, protoSubValue := range protoListValues {
@@ -356,7 +356,7 @@ func protoValueToValue(protoValue *checkv1.Value) (any, error) {
 		for i := 1; i < len(anySlice); i++ {
 			anySliceSubType := reflect.TypeOf(anySlice[i])
 			if anySliceFirstType != anySliceSubType {
-				return nil, fmt.Errorf("invalid checkv1.Value: list_values must have values of the same type but detected types %v and %v", anySliceFirstType, anySliceSubType)
+				return nil, fmt.Errorf("invalid optionv1.Value: list_values must have values of the same type but detected types %v and %v", anySliceFirstType, anySliceSubType)
 			}
 		}
 		reflectSlice := reflect.MakeSlice(reflect.SliceOf(anySliceFirstType), 0, len(anySlice))
@@ -365,7 +365,7 @@ func protoValueToValue(protoValue *checkv1.Value) (any, error) {
 		}
 		return reflectSlice.Interface(), nil
 	default:
-		return nil, errors.New("invalid checkv1.Value: no value of oneof is set")
+		return nil, errors.New("invalid optionv1.Value: no value of oneof is set")
 	}
 }
 

--- a/option/options_test.go
+++ b/option/options_test.go
@@ -21,7 +21,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package check
+package option
 
 import (
 	"testing"


### PR DESCRIPTION
In preparation for additional plugin types, this does some refactoring:

- Update buf.build/bufbuild/bufplugin to v0.2.0.
- Move `check.File` to `descriptor.FileDescriptor`.
- Move `check.Location` to `descriptor.FileLocation`.
- Move `check.Options` to `option.Options`.
- Rename fields as appropriate.