### PR TITLE
Bump tested Go versions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,6 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -24,13 +21,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
       - name: Test
         run: make test
       - name: Lint
-        # Often, lint & gofmt guidelines depend on the Go version. To prevent
-        # conflicting guidance, run only on the most recent supported version.
-        # For the same reason, only check generated code on the most recent
-        # supported version.
-        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.23.x, 1.24.x, 1.25.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -21,8 +24,13 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ matrix.go-version }}
       - name: Test
         run: make test
       - name: Lint
+        # Often, lint & gofmt guidelines depend on the Go version. To prevent
+        # conflicting guidance, run only on the most recent supported version.
+        # For the same reason, only check generated code on the most recent
+        # supported version.
+        if: matrix.go-version == '1.25.x'
         run: make checkgenerate && make lint

--- a/check/internal/example/buf.gen.yaml
+++ b/check/internal/example/buf.gen.yaml
@@ -7,7 +7,7 @@ managed:
     - file_option: go_package_prefix
       value: buf.build/go/bufplugin/check/internal/example/gen
 plugins:
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.6
     out: gen
     opt: paths=source_relative
 clean: true


### PR DESCRIPTION
We bumped to Go 1.23 support in https://github.com/bufbuild/bufplugin-go/pull/14, so we don't need to run our workflow on an unsupported version. Just run based on the go version in go.mod.